### PR TITLE
getWithDefault deprecated / being removed in Ember 4.0.0

### DIFF
--- a/addon/configuration.js
+++ b/addon/configuration.js
@@ -1,4 +1,4 @@
-import { getWithDefault } from '@ember/object';
+import { get } from '@ember/object';
 import { typeOf } from '@ember/utils';
 
 const DEFAULTS = {
@@ -43,7 +43,8 @@ export default {
         Object.prototype.hasOwnProperty.call(this, property)
         && typeOf(this[property]) !== 'function'
       ) {
-        this[property] = getWithDefault(config, property, DEFAULTS[property]);
+        const value = get(config, property);
+        this[property] = value === undefined ? DEFAULTS[property] : value;
       }
     }
   }


### PR DESCRIPTION
https://deprecations.emberjs.com/v3.x/#toc_ember-metal-get-with-default

getWithDefault being removed in 4.0.0